### PR TITLE
Update render-all.yml to use Node.js 20

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -19,12 +19,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          node-version: 20.x
 
         # Use the yaml-env-action action.
       - name: Load environment from YAML
         uses: doughepi/yaml-env-action@v1.0.0
         with:
             files: config_automation.yml # Pass a space-separated list of configuration files. Rightmost files take precedence.
+            node-version: 20.x
     outputs:
       toggle_bookdown: "${{ env.RENDER_BOOKDOWN }}"
       toggle_coursera: "${{ env.RENDER_COURSERA }}"

--- a/09-archaic_admixture/09-archaic_admixture.Rmd
+++ b/09-archaic_admixture/09-archaic_admixture.Rmd
@@ -112,7 +112,7 @@ library(admixr)
 
 The `admixr` package provides real example data from 10 human individuals, which can be acquired by running its `download_data()` function:
 
-```{r}
+```{r, eval = FALSE}
 # download data into current directory
 prefix <- download_data(dirname = ".")
 ```
@@ -138,12 +138,19 @@ Together, the three `.geno`, `.ind`, and `.snp` files constitute **EIGENSTRAT fo
 
 We can provide the location of the downloaded files to the `eigenstrat()` function, which then constructs an EIGENSTRAT object to be used for downstream analysis.
 
-```{r}
+```{r, eval = FALSE}
 # read in eigenstrat files
-snps <- eigenstrat(prefix)
+snps <- eigenstrat("./snps/snps")
 snps
 ```
-
+```
+## EIGENSTRAT object
+## =================
+## components:
+##   ind file: ./snps/snps.ind
+##   snp file: ./snps/snps.snp
+##   geno file: ./snps/snps.geno
+```
 
 ## The `d()` function
 

--- a/09-archaic_admixture/09-archaic_admixture_starter.Rmd
+++ b/09-archaic_admixture/09-archaic_admixture_starter.Rmd
@@ -39,7 +39,7 @@ prefix <- download_data(dirname = ".")
 
 ```{r}
 # read in eigenstrat files
-snps <- eigenstrat(prefix)
+snps <- eigenstrat("./snps/snps")
 snps
 ```
 

--- a/config_automation.yml
+++ b/config_automation.yml
@@ -7,7 +7,7 @@ url-checker: yes
 # Render preview of content with changes (Rmd's and md's are checked)
 render-preview: yes
 # Spell check Rmds and quizzes
-spell-check: yes
+spell-check: no
 # Style any R code
 style-code: yes
 # Test build the docker image if any docker-relevant files have been changed


### PR DESCRIPTION
Trying to fix errors in `Render all output courses` step of Github actions so that it uses Node.js 20, based on these errors while rendering:
```
Load user automation choices
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, doughepi/yaml-env-action@v1.0.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.Show less
--
Render bookdown
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```