### PR TITLE
Update install instructions for gwas2 module & some github actions files

### DIFF
--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -18,7 +18,7 @@ jobs:
 
       # Check out current repository
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Verify Dockerfiles changed?
         uses: tj-actions/verify-changed-files@v8.8

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Checkout files
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -18,16 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          node-version: 20.x
+        uses: actions/checkout@v4
 
         # Use the yaml-env-action action.
       - name: Load environment from YAML
         uses: doughepi/yaml-env-action@v1.0.0
         with:
             files: config_automation.yml # Pass a space-separated list of configuration files. Rightmost files take precedence.
-            node-version: 20.x
     outputs:
       toggle_bookdown: "${{ env.RENDER_BOOKDOWN }}"
       toggle_coursera: "${{ env.RENDER_COURSERA }}"
@@ -45,7 +42,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}

--- a/07-gwas2/README.md
+++ b/07-gwas2/README.md
@@ -22,10 +22,3 @@ Install these software packages:
 	* `tidyverse`
 	* `vcfR`
 	* `qqman`
-
-### Software to install to Posit Cloud:
-
-* [PLINK](https://www.cog-genomics.org/plink/) stable binary
-* R packages
-	* `vcfR`
- 	* `qqman`


### PR DESCRIPTION
- Remove redundant install instructions in gwas2 module
- Correctly change checkout@v3 -> v4 in github actions because github moved to Node.js 20